### PR TITLE
Return unread messages counter as number

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,7 +1,7 @@
 module.exports = Franz => {
     function getMessages() {
         const count = document.querySelector('.navigationItem-counter').innerText
-        Franz.setBadge(count ? count.substring(1, count.length - 1) : 0)
+        Franz.setBadge(count ? Number(count.substring(1, count.length - 1)) : 0)
     }
     Franz.loop(getMessages)
 }


### PR DESCRIPTION
Due to this recipe returning the unread messages count as a string, Franz will cascade all unread message counts as strings instead of adding them.
This will result in this error:
![Image](https://i.imgur.com/tyZJUL7.png)
Franz shows 1300 new messages
![Image](https://i.imgur.com/yCyhbC7.png)
Even though there is only 1 message on one provider and three on ProtonMail.

This PR will fix this issue by converting the unread count to a number before passing it to the `setBadge` function.
