### PR TITLE
Fix SVG icon

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
-    <g transform="matrix(1.52334,0,0,1.52334,148,0.999645)">
-        <path d="M238.688,0.021C238.688,0.021 40.811,-6.479 0,213.021L0,362.521C0,362.521 1.688,378.521 46.688,411.021C91.688,443.521 208.188,535.021 238.688,535.021C269.188,535.021 385.688,443.521 430.688,411.021C475.688,378.521 477.376,362.521 477.376,362.521L477.376,213.021C436.565,-6.479 238.688,0.021 238.688,0.021ZM374.188,294.521L238.688,294.521L103.188,294.521L103.188,213.021C130.688,104.021 238.688,102.521 238.688,102.521C238.688,102.521 346.688,104.021 374.188,213.021L374.188,294.521Z" style="fill:rgb(51,51,102);fill-rule:nonzero;"/>
-        <path d="M238.688,568.688C238.688,568.688 208.021,565.687 184.021,549.021C160.021,532.355 0,418.021 0,418.021L0,644.355C0,644.355 1.355,670.688 30.355,670.688L447.021,670.688C476.021,670.688 477.376,644.355 477.376,644.355L477.376,418.021C477.376,418.021 317.354,532.355 293.354,549.021C269.354,565.687 238.688,568.688 238.688,568.688Z" style="fill:rgb(51,51,102);fill-rule:nonzero;"/>
-    </g>
+<svg width="80" height="80" xml:space="preserve" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421" xmlns="http://www.w3.org/2000/svg">
+    <path d="M239 0S41-6 0 213v150s2 16 47 48c45 33 161 124 192 124 30 0 147-91 192-124 45-32 46-48 46-48V213C437-6 239 0 239 0zm135 295H103v-82c28-109 136-110 136-110s108 1 135 110z" style="fill:#336;fill-rule:nonzero" transform="translate(11) scale(.11962)"/>
+    <path d="M239 569s-31-3-55-20L0 418v226s1 27 30 27h417c29 0 30-27 30-27V418L293 549c-24 17-54 20-54 20z" style="fill:#336;fill-rule:nonzero" transform="translate(11) scale(.11962)"/>
 </svg>
-


### PR DESCRIPTION
Despite vantezzen's pull request, the SVG icon was still too big. This PR fixes it

![image](https://user-images.githubusercontent.com/39555268/155859755-568adc35-1094-45a1-b4b8-0366ebd73d97.png)
