### PR TITLE
Fixed an issue with proton mail login and electrons screwup with atob…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
+// Electron really screwed up here. atob and btoa are broken in recent versions, so override them.
+window.atob = data => Buffer.from(data, "base64").toString("latin1");
+window.btoa = data => Buffer.from(data, "latin1").toString("base64");
 module.exports = Franz => Franz;


### PR DESCRIPTION
Electron does not play nice with in browser encoding with atob and btoa for base 64 encoding and this causes an issue with the login page for proton mail when used inside of an electron app. This overrides the windows use of atob and btoa... 

Credit goes to: https://github.com/TheGoddessInari/hamsket/commit/2d8a4d1edc1faeb7583ee946a4584d7d98079853 and
https://github.com/TheGoddessInari/hamsket/issues/291 